### PR TITLE
provide signal handlers when INCLUDE_BREAKPAD active

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - request auth token on every retry, not just after 403
 - update to use nopoll v 1.0.2
 - provide signal handlers so we shut down properly when INCLUDE_BREAKPAD active
+- send status code and reason in close message 
 
 ## [1.0.2] - 2019-02-08
 - Refactored connection.c and updated corresponding unit tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - requestNewAuthToken will clear the token if it fails.
 - request auth token on every retry, not just after 403
 - update to use nopoll v 1.0.2
+- provide signal handlers so we shut down properly when INCLUDE_BREAKPAD active
 
 ## [1.0.2] - 2019-02-08
 - Refactored connection.c and updated corresponding unit tests

--- a/src/conn_interface.c
+++ b/src/conn_interface.c
@@ -211,6 +211,7 @@ void createSocketConnection(void (* initKeypress)())
 
     deleteAllClients ();
 
+    ParodusInfo ("reconnect reason at close %s\n", get_global_reconnect_reason()); 
     close_and_unref_connection(get_global_conn());
     nopoll_ctx_unref(ctx);
     nopoll_cleanup_library();

--- a/src/main.c
+++ b/src/main.c
@@ -35,7 +35,7 @@
 /*----------------------------------------------------------------------------*/
 /*                               Data Structures                              */
 /*----------------------------------------------------------------------------*/
-/* none */
+typedef    void    Sigfunc(int);
 
 /*----------------------------------------------------------------------------*/
 /*                            File Scoped Variables                           */
@@ -46,6 +46,28 @@
 /*                             Function Prototypes                            */
 /*----------------------------------------------------------------------------*/
 static void sig_handler(int sig);
+
+Sigfunc *
+signal (int signo, Sigfunc *func)
+{
+    struct sigaction act, oact;
+
+    act.sa_handler = func;
+    sigemptyset (&act.sa_mask);
+    act.sa_flags = 0;
+    if (signo == SIGALRM) {
+#ifdef  SA_INTERRUPT
+        act.sa_flags |= SA_INTERRUPT;     /* SunOS 4.x */
+#endif
+    } else {
+#ifdef  SA_RESTART
+        act.sa_flags |= SA_RESTART; /* SVR4, 4.4BSD */
+#endif
+    }
+    if (sigaction (signo, &act, &oact) < 0)
+        return (SIG_ERR);
+    return (oact.sa_handler);
+}
 
 /*----------------------------------------------------------------------------*/
 /*                             External Functions                             */

--- a/src/main.c
+++ b/src/main.c
@@ -55,21 +55,21 @@ static void sig_handler(int sig);
 /*----------------------------------------------------------------------------*/
 int main( int argc, char **argv)
 {
-#ifdef INCLUDE_BREAKPAD
-    breakpad_ExceptionHandler();
-#else
     signal(SIGTERM, sig_handler);
-	signal(SIGINT, sig_handler);
+    signal(SIGINT, sig_handler);
 	signal(SIGUSR1, sig_handler);
 	signal(SIGUSR2, sig_handler);
-	signal(SIGSEGV, sig_handler);
-	signal(SIGBUS, sig_handler);
 	signal(SIGKILL, sig_handler);
-	signal(SIGFPE, sig_handler);
-	signal(SIGILL, sig_handler);
 	signal(SIGQUIT, sig_handler);
 	signal(SIGHUP, sig_handler);
 	signal(SIGALRM, sig_handler);
+#ifdef INCLUDE_BREAKPAD
+    breakpad_ExceptionHandler();
+#else
+	signal(SIGSEGV, sig_handler);
+	signal(SIGBUS, sig_handler);
+	signal(SIGFPE, sig_handler);
+	signal(SIGILL, sig_handler);
 #endif	
     ParodusCfg *cfg;
 

--- a/src/main.c
+++ b/src/main.c
@@ -24,9 +24,8 @@
 #include <curl/curl.h>
 #ifdef INCLUDE_BREAKPAD
 #include "breakpad_wrapper.h"
-#else
-#include "signal.h"
 #endif
+#include "signal.h"
 
 /*----------------------------------------------------------------------------*/
 /*                                   Macros                                   */
@@ -46,9 +45,7 @@
 /*----------------------------------------------------------------------------*/
 /*                             Function Prototypes                            */
 /*----------------------------------------------------------------------------*/
-#ifndef INCLUDE_BREAKPAD
 static void sig_handler(int sig);
-#endif
 
 /*----------------------------------------------------------------------------*/
 /*                             External Functions                             */
@@ -97,7 +94,6 @@ const char *rdk_logger_module_fetch(void)
 /*----------------------------------------------------------------------------*/
 /*                             Internal functions                             */
 /*----------------------------------------------------------------------------*/
-#ifndef INCLUDE_BREAKPAD
 static void sig_handler(int sig)
 {
 
@@ -138,4 +134,3 @@ static void sig_handler(int sig)
 	}
 	
 }
-#endif

--- a/tests/test_conn_interface.c
+++ b/tests/test_conn_interface.c
@@ -88,6 +88,10 @@ void packMetaData()
     function_called();
 }
 
+char *get_global_reconnect_reason(void)
+{
+  return "Unknown";
+}
 
 int get_cloud_disconnect_time(void)
 {

--- a/tests/test_connection.c
+++ b/tests/test_connection.c
@@ -148,6 +148,11 @@ void nopoll_conn_close (noPollConn *conn)
     UNUSED(conn);
 }
 
+void nopoll_conn_close_ext (noPollConn *conn, int status, const char *reason, int reason_size)
+{
+    UNUSED(conn); UNUSED(status); UNUSED(reason); UNUSED(reason_size);
+}
+
 int nopoll_conn_ref_count (noPollConn *conn)
 {
     UNUSED(conn);


### PR DESCRIPTION
When INCLUDE_BREAKPAD is active, add signal handlers for signals not trapped by breakpad, so that parodus will shut down properly.  This is meant to address rdkb-23333.