### PR TITLE
Pause connection retry when interface is down

### DIFF
--- a/src/ParodusInternal.c
+++ b/src/ParodusInternal.c
@@ -28,6 +28,7 @@
 bool interface_down_event = false;
 
 pthread_mutex_t interface_down_mut=PTHREAD_MUTEX_INITIALIZER;
+pthread_cond_t interface_down_con=PTHREAD_COND_INITIALIZER;
 
 /*----------------------------------------------------------------------------*/
 /*                             External Functions                             */
@@ -164,6 +165,7 @@ void reset_interface_down_event()
 {
 	pthread_mutex_lock (&interface_down_mut);
 	interface_down_event = false;
+	pthread_cond_signal(&interface_down_con);
 	pthread_mutex_unlock (&interface_down_mut);
 }
 
@@ -175,6 +177,14 @@ void set_interface_down_event()
     	pthread_mutex_unlock (&interface_down_mut);
 }
 
+pthread_cond_t *get_interface_down_con(void)
+{
+    return &interface_down_con;
+}
 
+pthread_mutex_t *get_interface_down_mut(void)
+{
+    return &interface_down_mut;
+}
 
 

--- a/src/ParodusInternal.h
+++ b/src/ParodusInternal.h
@@ -170,6 +170,10 @@ void reset_interface_down_event();
 
 // Set value of interface_down_event to true
 void set_interface_down_event();
+
+pthread_cond_t *get_interface_down_con();
+
+pthread_mutex_t *get_interface_down_mut();
   
 
 #ifdef __cplusplus

--- a/src/connection.c
+++ b/src/connection.c
@@ -391,7 +391,7 @@ int nopoll_connect (create_connection_ctx_t *ctx, int is_ipv6)
    }
    if ((NULL == connection) && (!is_ipv6)) {
      if((checkHostIp(server->server_addr) == -2)) {
-       if (check_timer_expired (&ctx->connect_timer, 15*60*1000)) {
+       if (check_timer_expired (&ctx->connect_timer, 15*60*1000) && !get_interface_down_event()) {
   	 ParodusError("WebPA unable to connect due to DNS resolving to 10.0.0.1 for over 15 minutes; crashing service.\n");
 	 OnboardLog("WebPA unable to connect due to DNS resolving to 10.0.0.1 for over 15 minutes; crashing service.\n");
 	 OnboardLog("Reconnect detected, setting Dns_Res_webpa_reconnect reason for Reconnect\n");
@@ -580,6 +580,18 @@ int createNopollConnection(noPollCtx *ctx)
 	  if (keep_trying_to_connect (&conn_ctx, &backoff_timer))
 		break;
 	  // retry dns query
+
+	  // If interface down event is set, stop retry
+	  // and wait till interface is up again.
+	  if(get_interface_down_event()) {
+		ParodusError("Interface is down, hence pausing retry and waiting until its up\n");
+		pthread_mutex_lock(get_interface_down_mut());
+		pthread_cond_wait(get_interface_down_con(), get_interface_down_mut());
+		pthread_mutex_unlock (get_interface_down_mut());
+		ParodusInfo("Interface is back up, re-initializing the convey header\n");
+		// Reset the reconnect reason by initializing the convey header again
+		((header_info_t *)(&conn_ctx.header_info))->conveyHeader = getWebpaConveyHeader(); 
+	  }
 	}
       
 	if(conn_ctx.current_server->allow_insecure <= 0)

--- a/tests/test_connection.c
+++ b/tests/test_connection.c
@@ -60,7 +60,9 @@ extern int keep_trying_to_connect (create_connection_ctx_t *ctx,
 
 bool close_retry;
 bool LastReasonStatus;
-pthread_mutex_t close_mut;
+pthread_mutex_t close_mut; 
+pthread_mutex_t interface_down_mut=PTHREAD_MUTEX_INITIALIZER;
+pthread_cond_t interface_down_con=PTHREAD_COND_INITIALIZER;
 
 // Mock values
 bool g_shutdown = false;
@@ -78,6 +80,20 @@ noPollConn connection3;
 char* getWebpaConveyHeader()
 {
     return (char*) "WebPA-1.6 (TG1682)";
+}
+
+bool get_interface_down_event() 
+{
+	return false;
+}
+pthread_cond_t *get_interface_down_con(void)
+{
+    return &interface_down_con;
+}
+
+pthread_mutex_t *get_interface_down_mut(void)
+{
+    return &interface_down_mut;
 }
 
 noPollConn * nopoll_conn_new_opts (noPollCtx  * ctx, noPollConnOpts  * opts, const char  * host_ip, const char  * host_port, const char  * host_name,const char  * get_url,const char  * protocols, const char * origin)


### PR DESCRIPTION
Pause cloud connection retry when interface is down and resume it once the network interface is up.