### PR TITLE
provide signal handlers when INCLUDE_BREAKPAD active

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - requestNewAuthToken will clear the token if it fails.
 - request auth token on every retry, not just after 403
 - update to use nopoll v 1.0.2
+- provide signal handlers so we shut down properly when INCLUDE_BREAKPAD active
+- send status code and reason in close message 
 - Add pause/resume heartBeatTimer
 - parodus event handler to listen to interface_down and interface_up event
 - Pause connection retry during interface_down event

--- a/src/conn_interface.c
+++ b/src/conn_interface.c
@@ -209,13 +209,16 @@ void createSocketConnection(void (* initKeypress)())
 
     deleteAllClients ();
 
+    ParodusInfo ("reconnect reason at close %s\n", get_global_reconnect_reason());
+    ParodusInfo ("shutdown reason at close %s\n", get_global_shutdown_reason()); 
     close_and_unref_connection(get_global_conn());
     nopoll_ctx_unref(ctx);
     nopoll_cleanup_library();
     curl_global_cleanup();
 }
 
-void shutdownSocketConnection(void) {
+void shutdownSocketConnection(char *reason) {
+   set_global_shutdown_reason (reason);
    g_shutdown = true;
 }
 

--- a/src/conn_interface.h
+++ b/src/conn_interface.h
@@ -45,7 +45,7 @@ extern UpStreamMsg *UpStreamMsgQ;
  *  and creates the intial connection and manages the connection wait, close mechanisms.
  */
 void createSocketConnection(void (* initKeypress)());
-void shutdownSocketConnection(void);
+void shutdownSocketConnection(char *reason);
    
 #ifdef __cplusplus
 }

--- a/src/connection.c
+++ b/src/connection.c
@@ -39,10 +39,29 @@
 #define HTTP_CUSTOM_HEADER_COUNT                    	5
 #define INITIAL_CJWT_RETRY                    	-2
 
+/* Close codes defined in RFC 6455, section 11.7. */
+enum {
+	CloseNormalClosure           = 1000,
+	CloseGoingAway               = 1001,
+	CloseProtocolError           = 1002,
+	CloseUnsupportedData         = 1003,
+	CloseNoStatus		     = 1005,
+	CloseAbnormalClosure         = 1006,
+	CloseInvalidFramePayloadData = 1007,
+	ClosePolicyViolation         = 1008,
+	CloseMessageTooBig           = 1009,
+	CloseMandatoryExtension      = 1010,
+	CloseInternalServerErr       = 1011,
+	CloseServiceRestart          = 1012,
+	CloseTryAgainLater           = 1013,
+	CloseTLSHandshake            = 1015
+};
+
 /*----------------------------------------------------------------------------*/
 /*                            File Scoped Variables                           */
 /*----------------------------------------------------------------------------*/
 
+static char *shutdown_reason = SHUTDOWN_REASON_PARODUS_STOP;  /* goes in the close message */
 static char *reconnect_reason = "webpa_process_starts";
 static int cloud_disconnect_max_time = 5;
 static noPollConn *g_conn = NULL;
@@ -63,6 +82,16 @@ noPollConn *get_global_conn(void)
 void set_global_conn(noPollConn *conn)
 {
     g_conn = conn;
+}
+
+char *get_global_shutdown_reason()
+{
+    return shutdown_reason;
+}
+
+void set_global_shutdown_reason(char *reason)
+{
+    shutdown_reason = reason;
 }
 
 char *get_global_reconnect_reason()
@@ -681,9 +710,14 @@ static noPollConnOpts * createConnOpts (char * extra_headers, bool secure)
 void close_and_unref_connection(noPollConn *conn)
 {
     if (conn) {
-        nopoll_conn_close(conn);
-        get_parodus_cfg()->cloud_status = CLOUD_STATUS_OFFLINE;
-      	ParodusInfo("cloud_status set as %s after connection close\n", get_parodus_cfg()->cloud_status);
+	const char *reason = get_global_shutdown_reason();
+	int reason_len = 0;
+	int status = CloseNoStatus;
+	if (NULL != reason) {
+		reason_len = (int) strlen (reason);
+		status = CloseNormalClosure;
+	}
+        nopoll_conn_close_ext(conn, status, reason, reason_len);
         if (0 < nopoll_conn_ref_count (conn)) {
             nopoll_conn_unref(conn);
         }

--- a/src/connection.h
+++ b/src/connection.h
@@ -33,7 +33,8 @@ extern "C" {
 /*----------------------------------------------------------------------------*/
 /*                            File Scoped Variables                           */
 /*----------------------------------------------------------------------------*/
-
+#define SHUTDOWN_REASON_PARODUS_STOP    "parodus_stopping"
+#define SHUTDOWN_REASON_SYSTEM_RESTART  "system_restarting"
 
 /*----------------------------------------------------------------------------*/
 /*                             Function Prototypes                            */
@@ -48,6 +49,9 @@ void close_and_unref_connection(noPollConn *);
 
 noPollConn *get_global_conn(void);
 void set_global_conn(noPollConn *);
+
+char *get_global_shutdown_reason();
+void set_global_shutdown_reason(char *reason);
 
 char *get_global_reconnect_reason();
 void set_global_reconnect_reason(char *reason);

--- a/src/main.c
+++ b/src/main.c
@@ -19,14 +19,14 @@
 #include "stdlib.h"
 #include "config.h"
 #include "auth_token.h"
+#include "connection.h"
 #include "conn_interface.h"
 #include "parodus_log.h"
 #include <curl/curl.h>
 #ifdef INCLUDE_BREAKPAD
 #include "breakpad_wrapper.h"
-#else
-#include "signal.h"
 #endif
+#include "signal.h"
 
 /*----------------------------------------------------------------------------*/
 /*                                   Macros                                   */
@@ -36,7 +36,7 @@
 /*----------------------------------------------------------------------------*/
 /*                               Data Structures                              */
 /*----------------------------------------------------------------------------*/
-/* none */
+typedef    void    Sigfunc(int);
 
 /*----------------------------------------------------------------------------*/
 /*                            File Scoped Variables                           */
@@ -46,30 +46,53 @@
 /*----------------------------------------------------------------------------*/
 /*                             Function Prototypes                            */
 /*----------------------------------------------------------------------------*/
-#ifndef INCLUDE_BREAKPAD
 static void sig_handler(int sig);
+
+Sigfunc *
+signal (int signo, Sigfunc *func)
+{
+    struct sigaction act, oact;
+
+    act.sa_handler = func;
+    sigemptyset (&act.sa_mask);
+    act.sa_flags = 0;
+    if (signo == SIGALRM) {
+#ifdef  SA_INTERRUPT
+        act.sa_flags |= SA_INTERRUPT;     /* SunOS 4.x */
 #endif
+    } else {
+#ifdef  SA_RESTART
+        act.sa_flags |= SA_RESTART; /* SVR4, 4.4BSD */
+#endif
+    }
+    if (sigaction (signo, &act, &oact) < 0) {
+	ParodusError ("Signal Handler for signal %d not installed!\n", signo);
+        return (SIG_ERR);
+    }
+    return (oact.sa_handler);
+}
 
 /*----------------------------------------------------------------------------*/
 /*                             External Functions                             */
 /*----------------------------------------------------------------------------*/
 int main( int argc, char **argv)
 {
-#ifdef INCLUDE_BREAKPAD
-    breakpad_ExceptionHandler();
-#else
+    set_global_shutdown_reason (SHUTDOWN_REASON_PARODUS_STOP);
     signal(SIGTERM, sig_handler);
-	signal(SIGINT, sig_handler);
+    signal(SIGINT, sig_handler);
 	signal(SIGUSR1, sig_handler);
 	signal(SIGUSR2, sig_handler);
-	signal(SIGSEGV, sig_handler);
-	signal(SIGBUS, sig_handler);
 	signal(SIGKILL, sig_handler);
-	signal(SIGFPE, sig_handler);
-	signal(SIGILL, sig_handler);
 	signal(SIGQUIT, sig_handler);
 	signal(SIGHUP, sig_handler);
 	signal(SIGALRM, sig_handler);
+#ifdef INCLUDE_BREAKPAD
+    breakpad_ExceptionHandler();
+#else
+	signal(SIGSEGV, sig_handler);
+	signal(SIGBUS, sig_handler);
+	signal(SIGFPE, sig_handler);
+	signal(SIGILL, sig_handler);
 #endif	
     ParodusCfg *cfg;
 
@@ -97,7 +120,6 @@ const char *rdk_logger_module_fetch(void)
 /*----------------------------------------------------------------------------*/
 /*                             Internal functions                             */
 /*----------------------------------------------------------------------------*/
-#ifndef INCLUDE_BREAKPAD
 static void sig_handler(int sig)
 {
 
@@ -105,12 +127,13 @@ static void sig_handler(int sig)
 	{
 		signal(SIGINT, sig_handler); /* reset it to this function */
 		ParodusInfo("SIGINT received!\n");
-		shutdownSocketConnection();
+		shutdownSocketConnection(SHUTDOWN_REASON_PARODUS_STOP);
 	}
 	else if ( sig == SIGUSR1 ) 
 	{
 		signal(SIGUSR1, sig_handler); /* reset it to this function */
 		ParodusInfo("SIGUSR1 received!\n");
+		shutdownSocketConnection(SHUTDOWN_REASON_SYSTEM_RESTART);
 	}
 	else if ( sig == SIGUSR2 ) 
 	{
@@ -134,8 +157,7 @@ static void sig_handler(int sig)
 	else 
 	{
 		ParodusInfo("Signal %d received!\n", sig);
-		shutdownSocketConnection();
+		shutdownSocketConnection(SHUTDOWN_REASON_PARODUS_STOP);
 	}
 	
 }
-#endif

--- a/tests/test_conn_interface.c
+++ b/tests/test_conn_interface.c
@@ -33,6 +33,7 @@
 /*----------------------------------------------------------------------------*/
 /*                            File Scoped Variables                           */
 /*----------------------------------------------------------------------------*/
+static char *reconnect_reason = "webpa_process_starts";
 UpStreamMsg *UpStreamMsgQ;
 ParodusMsg *ParodusMsgQ;
 pthread_mutex_t g_mutex=PTHREAD_MUTEX_INITIALIZER;
@@ -73,6 +74,21 @@ noPollMutexUnlock 	mutex_unlock
 {
     UNUSED(mutex_create); UNUSED(mutex_destroy); UNUSED(mutex_lock); UNUSED(mutex_unlock);
     function_called();
+}
+
+char *get_global_reconnect_reason()
+{
+    return reconnect_reason;
+}
+
+char *get_global_shutdown_reason()
+{
+    return SHUTDOWN_REASON_PARODUS_STOP;
+}
+
+void set_global_shutdown_reason(char *reason)
+{
+    UNUSED(reason);
 }
 
 void start_conn_in_progress (void)

--- a/tests/test_connection.c
+++ b/tests/test_connection.c
@@ -181,6 +181,11 @@ void nopoll_conn_close (noPollConn *conn)
     UNUSED(conn);
 }
 
+void nopoll_conn_close_ext (noPollConn *conn, int status, const char *reason, int reason_size)
+{
+    UNUSED(conn); UNUSED(status); UNUSED(reason); UNUSED(reason_size);
+}
+
 int nopoll_conn_ref_count (noPollConn *conn)
 {
     UNUSED(conn);


### PR DESCRIPTION
When INCLUDE_BREAKPAD is active, add signal handlers for signals not trapped by breakpad, so that parodus will shut down properly. This is meant to address rdkb-23333.

Which signal will determine close message.
SIGUSR1 will cause "system_restarting" to be sent.
Other signals will cause "parodus_stopping" to be sent.
