### PR TITLE
update backoff_delay for interface_down

### DIFF
--- a/src/ParodusInternal.h
+++ b/src/ParodusInternal.h
@@ -49,6 +49,13 @@
 /*----------------------------------------------------------------------------*/
 /*                                   Macros                                   */
 /*----------------------------------------------------------------------------*/
+#define TEST_CONNECTION_STUCK 1
+
+#ifdef TEST_CONNECTION_STUCK
+#include <sys/stat.h>
+#endif
+
+
 #define UNUSED(x) (void )(x)
 #define NANO_SOCKET_SEND_TIMEOUT_MS                     2000
 #define NANO_SOCKET_RCV_TIMEOUT_MS			500

--- a/src/ParodusInternal.h
+++ b/src/ParodusInternal.h
@@ -49,12 +49,6 @@
 /*----------------------------------------------------------------------------*/
 /*                                   Macros                                   */
 /*----------------------------------------------------------------------------*/
-#define TEST_CONNECTION_STUCK 1
-
-#ifdef TEST_CONNECTION_STUCK
-#include <sys/stat.h>
-#endif
-
 
 #define UNUSED(x) (void )(x)
 #define NANO_SOCKET_SEND_TIMEOUT_MS                     2000
@@ -114,6 +108,7 @@ typedef struct {
 
 //--- Used in connection.c for backoff delay timer
 typedef struct {
+  struct timespec ts;
   int count;
   int max_count;
   int delay;

--- a/src/conn_interface.c
+++ b/src/conn_interface.c
@@ -168,6 +168,10 @@ void createSocketConnection(void (* initKeypress)())
         if( false == seshat_registered ) {
             seshat_registered = __registerWithSeshat();
         }
+        
+        if (get_interface_down_event ())
+          if (0 != wait_while_interface_down ())
+            break;
 
         if(get_close_retry())
         {
@@ -223,5 +227,6 @@ void createSocketConnection(void (* initKeypress)())
 void shutdownSocketConnection(void) {
    g_shutdown = true;
    reset_interface_down_event ();
+   terminate_backoff_delay ();
 }
 

--- a/src/conn_interface.c
+++ b/src/conn_interface.c
@@ -222,5 +222,6 @@ void createSocketConnection(void (* initKeypress)())
 
 void shutdownSocketConnection(void) {
    g_shutdown = true;
+   reset_interface_down_event ();
 }
 

--- a/src/connection.c
+++ b/src/connection.c
@@ -32,6 +32,8 @@
 #include "ParodusInternal.h"
 #include "heartBeat.h"
 #include "close_retry.h"
+
+
 /*----------------------------------------------------------------------------*/
 /*                                   Macros                                   */
 /*----------------------------------------------------------------------------*/
@@ -622,6 +624,16 @@ int createNopollConnection(noPollCtx *ctx)
   struct timespec connect_time,*connectTimePtr;
   connectTimePtr = &connect_time;
   backoff_timer_t backoff_timer;
+#ifdef TEST_CONNECTION_STUCK
+  struct stat sb;
+
+  if (stat ("/tmp/parconnstktest.txt", &sb) == 0) {
+    while (true) {
+      ParodusError ("parodus simulating connection stuck.\n");
+      sleep (60);
+    }
+  }
+#endif
   
   if(ctx == NULL) {
         return nopoll_false;

--- a/src/connection.c
+++ b/src/connection.c
@@ -274,6 +274,8 @@ static int backoff_delay (backoff_timer_t *timer)
   }
   if (waiting_interface)
     return BACKOFF_IFC_UP;
+  if ((timer->count >= timer->max_count) || (timer->delay >= 15))
+    start_conn_in_progress ();
   return BACKOFF_DELAY_TAKEN;
 }
 

--- a/src/connection.h
+++ b/src/connection.h
@@ -75,6 +75,11 @@ void stop_conn_in_progress (void);
 // To Register parodusOnPingStatusChangeHandler Callback function
 void registerParodusOnPingStatusChangeHandler(parodusOnPingStatusChangeHandler on_ping_status_change);
 
+// To stop connection and wait duing interface down state
+int wait_while_interface_down (void);
+
+void terminate_backoff_delay (void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/tests/test_conn_interface.c
+++ b/tests/test_conn_interface.c
@@ -87,6 +87,21 @@ void reset_interface_down_event (void)
 {
 }
 
+bool get_interface_down_event (void)
+{
+	return false;
+}
+
+int wait_while_interface_down (void)
+{
+	return 0;
+}
+
+void terminate_backoff_delay (void)
+{
+}
+
+
 void packMetaData()
 {
     function_called();

--- a/tests/test_conn_interface.c
+++ b/tests/test_conn_interface.c
@@ -83,6 +83,10 @@ void stop_conn_in_progress (void)
 {
 }   
 
+void reset_interface_down_event (void)
+{
+}
+
 void packMetaData()
 {
     function_called();

--- a/tests/test_connection.c
+++ b/tests/test_connection.c
@@ -1061,10 +1061,6 @@ void test_interface_down_retry()
   noPollCtx test_nopoll_ctx;
   pthread_t thread_a;
 
-#ifdef TEST_CONNECTION_STUCK
-  unlink ("/tmp/parconnstktest.txt");
-#endif
-
   pthread_create(&thread_a, NULL, a, NULL);
 
   memset(&cfg,0,sizeof(cfg));

--- a/tests/test_connection.c
+++ b/tests/test_connection.c
@@ -915,6 +915,9 @@ void test_create_nopoll_connection()
   ParodusCfg cfg;
   noPollCtx test_nopoll_ctx;
 
+#ifdef TEST_CONNECTION_STUCK
+  unlink ("/tmp/parconnstktest.txt");
+#endif
   memset(&cfg,0,sizeof(cfg));
   cfg.flags = 0;
   parStrncpy (cfg.webpa_url, "mydns.mycom.net:8080", sizeof(cfg.webpa_url));
@@ -1057,6 +1060,10 @@ void test_interface_down_retry()
   ParodusCfg cfg;
   noPollCtx test_nopoll_ctx;
   pthread_t thread_a;
+
+#ifdef TEST_CONNECTION_STUCK
+  unlink ("/tmp/parconnstktest.txt");
+#endif
 
   pthread_create(&thread_a, NULL, a, NULL);
 


### PR DESCRIPTION
Update backoff_delay in connection.c to deal with interface_down situation and allow breakout on g_shutdown.