### PR TITLE
two times into parconnhealth file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - fix so that parodus can be killed, even if in a connection fail loop
 - provide signal handlers so we shut down properly when INCLUDE_BREAKPAD active
 - send status code and reason in websocket close message
-- dont try to install handler for signal 9 
+- dont try to install handler for signal 9
+- put two timestamps in connection health file: start conn and current
 
 ## [1.0.2] - 2019-02-08
 - Refactored connection.c and updated corresponding unit tests

--- a/src/ParodusInternal.h
+++ b/src/ParodusInternal.h
@@ -108,6 +108,7 @@ typedef struct {
 
 //--- Used in connection.c for backoff delay timer
 typedef struct {
+  unsigned long start_time;
   struct timespec ts;
   int count;
   int max_count;

--- a/src/conn_interface.c
+++ b/src/conn_interface.c
@@ -95,9 +95,7 @@ void createSocketConnection(void (* initKeypress)())
     nopoll_log_set_handler (ctx, __report_log, NULL);
     #endif
 
-    start_conn_in_progress ();
     create_conn_rtn = createNopollConnection(ctx);
-    stop_conn_in_progress ();
     if(!create_conn_rtn)
     {
 		ParodusError("Unrecovered error, terminating the process\n");
@@ -190,9 +188,7 @@ void createSocketConnection(void (* initKeypress)())
 		free(get_parodus_cfg()->cloud_disconnect);
 		reset_cloud_disconnect_reason(get_parodus_cfg());
             }
-            start_conn_in_progress ();
             createNopollConnection(ctx);
-            stop_conn_in_progress ();
         }
        } while(!get_close_retry() && !g_shutdown);
 

--- a/src/connection.c
+++ b/src/connection.c
@@ -738,7 +738,7 @@ int createNopollConnection(noPollCtx *ctx)
 	set_global_reconnect_status(false);
 	ParodusPrint("LastReasonStatus reset after successful connection\n");
 	setMessageHandlers();
-    stop_conn_in_progress (backoff_timer.start_time);
+    stop_conn_in_progress ();
 	return nopoll_true;
 }          
 
@@ -805,7 +805,7 @@ void close_and_unref_connection(noPollConn *conn)
     }
 }
 
-void write_conn_in_prog_file (const char *msg, unsigned long start_time)
+void write_conn_in_prog_file (bool is_starting, unsigned long start_time)
 {
   int fd;
   FILE *fp;
@@ -826,19 +826,22 @@ void write_conn_in_prog_file (const char *msg, unsigned long start_time)
     return;
   }
   timestamp = (unsigned long) time(NULL);
-  fprintf (fp, "{%s=%lu,%lu}\n", msg, start_time, timestamp);
-   
+  if (is_starting)
+    fprintf (fp, "{START=%lu,%lu}\n", start_time, timestamp);
+  else
+    fprintf (fp, "{STOP=%lu}\n", timestamp);
+  
   fclose (fp);
 }
 
 void start_conn_in_progress (unsigned long start_time)
 {
-  write_conn_in_prog_file ("START", start_time);
+  write_conn_in_prog_file (true, start_time);
 }   
 
-void stop_conn_in_progress (unsigned long start_time)
+void stop_conn_in_progress (void)
 {
-  write_conn_in_prog_file ("STOP", start_time);
+  write_conn_in_prog_file (false, 0);
 }   
 
 

--- a/src/connection.c
+++ b/src/connection.c
@@ -38,7 +38,7 @@
 
 #define HTTP_CUSTOM_HEADER_COUNT                    	5
 #define INITIAL_CJWT_RETRY                    	-2
-#define UPDATE_HEALTH_FILE_INTERVAL_SECS		450
+#define UPDATE_HEALTH_FILE_INTERVAL_SECS		300
 
 /* Close codes defined in RFC 6455, section 11.7. */
 enum {
@@ -233,6 +233,7 @@ void init_backoff_timer (backoff_timer_t *timer, int max_count)
   timer->max_count = max_count;
   timer->delay = 1;
   clock_gettime (CLOCK_REALTIME, &timer->ts);
+  timer->start_time = time(NULL);
 }
 
 void terminate_backoff_delay (void)
@@ -256,7 +257,7 @@ int update_backoff_delay (backoff_timer_t *timer)
 #define BACKOFF_SHUTDOWN   1
 #define BACKOFF_DELAY_TAKEN 0
 
-void start_conn_in_progress (void);
+void start_conn_in_progress (unsigned long start_time);
 
 /* backoff_delay
  * 
@@ -275,7 +276,7 @@ static int backoff_delay (backoff_timer_t *timer)
   // periodically update the health file.
   clock_gettime (CLOCK_REALTIME, &ts);
   if ((ts.tv_sec - timer->ts.tv_sec) >= UPDATE_HEALTH_FILE_INTERVAL_SECS) {
-    start_conn_in_progress ();
+    start_conn_in_progress (timer->start_time);
     timer->ts.tv_sec += UPDATE_HEALTH_FILE_INTERVAL_SECS;
   }	  
 
@@ -615,7 +616,7 @@ int keep_trying_to_connect (create_connection_ctx_t *ctx,
       if(get_interface_down_event()) {
 	    if (0 != wait_while_interface_down())
 	      return false;
-	    start_conn_in_progress();
+	    start_conn_in_progress(backoff_timer->start_time);
 	    ParodusInfo("Interface is back up, re-initializing the convey header\n");
 	    // Reset the reconnect reason by initializing the convey header again
 	    ((header_info_t *)(&ctx->header_info))->conveyHeader = getWebpaConveyHeader();
@@ -687,7 +688,7 @@ int createNopollConnection(noPollCtx *ctx)
 	init_header_info (&conn_ctx.header_info);
         set_server_list_null (&conn_ctx.server_list);
         init_backoff_timer (&backoff_timer, max_retry_count);
-  
+    start_conn_in_progress (backoff_timer.start_time); 
 	while (!g_shutdown)
 	{
 	  query_dns_status = find_servers (&conn_ctx.server_list);
@@ -737,7 +738,7 @@ int createNopollConnection(noPollCtx *ctx)
 	set_global_reconnect_status(false);
 	ParodusPrint("LastReasonStatus reset after successful connection\n");
 	setMessageHandlers();
-
+    stop_conn_in_progress (backoff_timer.start_time);
 	return nopoll_true;
 }          
 
@@ -804,7 +805,7 @@ void close_and_unref_connection(noPollConn *conn)
     }
 }
 
-void write_conn_in_prog_file (const char *msg)
+void write_conn_in_prog_file (const char *msg, unsigned long start_time)
 {
   int fd;
   FILE *fp;
@@ -825,18 +826,19 @@ void write_conn_in_prog_file (const char *msg)
     return;
   }
   timestamp = (unsigned long) time(NULL);
-  fprintf (fp, "{%s=%lu}\n", msg, timestamp);
+  fprintf (fp, "{%s=%lu,%lu}\n", msg, start_time, timestamp);
+   
   fclose (fp);
 }
 
-void start_conn_in_progress (void)
+void start_conn_in_progress (unsigned long start_time)
 {
-  write_conn_in_prog_file ("START");
+  write_conn_in_prog_file ("START", start_time);
 }   
 
-void stop_conn_in_progress (void)
+void stop_conn_in_progress (unsigned long start_time)
 {
-  write_conn_in_prog_file ("STOP");
+  write_conn_in_prog_file ("STOP", start_time);
 }   
 
 

--- a/src/connection.h
+++ b/src/connection.h
@@ -75,7 +75,7 @@ void set_cloud_disconnect_time(int disconnTime);
  * @brief Interface to self heal connection in progress getting stuck
  */
 void start_conn_in_progress (unsigned long start_time);
-void stop_conn_in_progress (unsigned long start_time);
+void stop_conn_in_progress (void);
 
 // To Register parodusOnPingStatusChangeHandler Callback function
 void registerParodusOnPingStatusChangeHandler(parodusOnPingStatusChangeHandler on_ping_status_change);

--- a/src/connection.h
+++ b/src/connection.h
@@ -74,8 +74,8 @@ void set_cloud_disconnect_time(int disconnTime);
 /**
  * @brief Interface to self heal connection in progress getting stuck
  */
-void start_conn_in_progress (void);
-void stop_conn_in_progress (void);
+void start_conn_in_progress (unsigned long start_time);
+void stop_conn_in_progress (unsigned long start_time);
 
 // To Register parodusOnPingStatusChangeHandler Callback function
 void registerParodusOnPingStatusChangeHandler(parodusOnPingStatusChangeHandler on_ping_status_change);

--- a/tests/test_conn_interface.c
+++ b/tests/test_conn_interface.c
@@ -91,12 +91,14 @@ void set_global_shutdown_reason(char *reason)
     UNUSED(reason);
 }
 
-void start_conn_in_progress (void)
+void start_conn_in_progress (unsigned long start_time)
 {
+	UNUSED(start_time);
 }   
 
-void stop_conn_in_progress (void)
+void stop_conn_in_progress (unsigned long start_time)
 {
+	UNUSED(start_time);
 }   
 
 void reset_interface_down_event (void)

--- a/tests/test_conn_interface.c
+++ b/tests/test_conn_interface.c
@@ -96,9 +96,8 @@ void start_conn_in_progress (unsigned long start_time)
 	UNUSED(start_time);
 }   
 
-void stop_conn_in_progress (unsigned long start_time)
+void stop_conn_in_progress (void)
 {
-	UNUSED(start_time);
 }   
 
 void reset_interface_down_event (void)


### PR DESCRIPTION
Write two timestamp values into the connection health file.
One will update every 5 minutes, while a connection is being attempted.
The other will just be the start time of the connection, and will not be updated during the connection.

These two values will be used in the task_health_monitor script.