### PR TITLE
add detection of redirect handshake error

### DIFF
--- a/src/connection.c
+++ b/src/connection.c
@@ -580,8 +580,8 @@ int wait_connection_ready (create_connection_ctx_t *ctx)
 	OnboardLog("Received Unauthorized response with status: %d\n", wait_status);
     return WAIT_ACTION_RETRY;
   }
-  if (!server_is_null (&ctx->server_list->redirect)) {
-    ParodusError("Client connection timeout after redirect\n");	
+  if ((wait_status == 0) && !server_is_null (&ctx->server_list->redirect)) {
+    ParodusError("Client connection timeout after no response from redirect URL\n");	
     return WAIT_REDIR_FAIL;
   }
   ParodusError("Client connection timeout\n");	

--- a/src/connection.h
+++ b/src/connection.h
@@ -76,7 +76,7 @@ void set_cloud_disconnect_time(int disconnTime);
 /**
  * @brief Interface to self heal connection in progress getting stuck
  */
-void start_conn_in_progress (unsigned long start_time);
+void start_conn_in_progress (unsigned long start_time, bool redir_handshake_err);
 void stop_conn_in_progress (void);
 
 // To Register parodusOnPingStatusChangeHandler Callback function

--- a/tests/test_conn_interface.c
+++ b/tests/test_conn_interface.c
@@ -102,9 +102,9 @@ void set_global_shutdown_reason(char *reason)
     UNUSED(reason);
 }
 
-void start_conn_in_progress (unsigned long start_time)
-{
-	UNUSED(start_time);
+void start_conn_in_progress (unsigned long start_time, bool redir_handshake_err)
+{ 
+	UNUSED(start_time); UNUSED(redir_handshake_err);
 }   
 
 void stop_conn_in_progress (void)


### PR DESCRIPTION
Do not merge.

Adds detection of handshake error after a redirect, and writes 3 values to the START record in the health monitor file.
