### PR TITLE
fix shutdown close msg to agree with splunk log

### DIFF
--- a/src/conn_interface.c
+++ b/src/conn_interface.c
@@ -179,7 +179,7 @@ void createSocketConnection(void (* initKeypress)())
         if(get_close_retry())
         {
             ParodusInfo("close_retry is %d, hence closing the connection and retrying\n", get_close_retry());
-            close_and_unref_connection(get_global_conn());
+            close_and_unref_connection(get_global_conn(), false);
             set_global_conn(NULL);
 
             if(get_parodus_cfg()->cloud_disconnect !=NULL)
@@ -220,8 +220,7 @@ void createSocketConnection(void (* initKeypress)())
     deleteAllClients ();
 
     ParodusInfo ("reconnect reason at close %s\n", get_global_reconnect_reason());
-    ParodusInfo ("shutdown reason at close %s\n", get_global_shutdown_reason()); 
-    close_and_unref_connection(get_global_conn());
+    close_and_unref_connection(get_global_conn(), true);
     nopoll_ctx_unref(ctx);
     nopoll_cleanup_library();
     curl_global_cleanup();

--- a/src/connection.h
+++ b/src/connection.h
@@ -56,7 +56,7 @@ int createNopollConnection(noPollCtx *, server_list_t *);
 /**
  * @brief Interface to terminate WebSocket client connections and clean up resources.
  */
-void close_and_unref_connection(noPollConn *);
+void close_and_unref_connection(noPollConn *conn, bool is_shutting_down);
 
 noPollConn *get_global_conn(void);
 void set_global_conn(noPollConn *);

--- a/tests/test_conn_interface.c
+++ b/tests/test_conn_interface.c
@@ -190,9 +190,9 @@ void set_global_reconnect_status(bool status)
     function_called();
 }
 
-void close_and_unref_connection(noPollConn *conn)
+void close_and_unref_connection(noPollConn *conn, bool is_shutting_down)
 {
-    UNUSED(conn);
+    UNUSED(conn); UNUSED(is_shutting_down);
     function_called();
 }
 

--- a/tests/test_connection.c
+++ b/tests/test_connection.c
@@ -268,7 +268,7 @@ void test_set_global_reconnect_reason()
 
 void test_closeConnection()
 {
-    close_and_unref_connection(get_global_conn());
+    close_and_unref_connection(get_global_conn(), false);
 }
 
 void test_server_is_null()


### PR DESCRIPTION
Fix logic in close_and_unref_connection so that splunk log agrees with parodus close message.