### PR TITLE
Fix Parodus connection stuck on interface up down received together

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 - Add additional HTTP headers for call to Themis from Convey
 - Add callback handler for initial cloud connection status change event
+- Fix Parodus connection stuck on interface up down received together
 
 ## [1.1.4]
 - on connect retry, requery jwt only if it failed before 

--- a/src/conn_interface.c
+++ b/src/conn_interface.c
@@ -195,7 +195,8 @@ void createSocketConnection(void (* initKeypress)())
             }
             createNopollConnection(ctx, &server_list);
         }
-       } while(!get_close_retry() && !g_shutdown);
+	 //process exit only when g_shutdown is true.
+       } while(!g_shutdown);
 
     pthread_mutex_lock (get_global_svc_mut());
     pthread_cond_signal (get_global_svc_con());

--- a/src/conn_interface.c
+++ b/src/conn_interface.c
@@ -196,7 +196,7 @@ void createSocketConnection(void (* initKeypress)())
             createNopollConnection(ctx, &server_list);
         }
 	 //process exit only when g_shutdown is true.
-       } while(!g_shutdown);
+       } while(FOREVER() && !g_shutdown);
 
     pthread_mutex_lock (get_global_svc_mut());
     pthread_cond_signal (get_global_svc_con());

--- a/src/connection.c
+++ b/src/connection.c
@@ -699,7 +699,8 @@ int wait_while_interface_down()
   	  if (rtn != 0)
   	    ParodusError 
   	      ("Error on pthread_cond_wait (%d) in wait_while_interface_down\n", rtn);
-  	  if ((rtn != 0) || g_shutdown) {
+	  if (g_shutdown) {
+	    ParodusInfo("Received g_shutdown during interface down wait, returning\n");
 	    return -1;
 	  }
 	}

--- a/tests/test_conn_interface.c
+++ b/tests/test_conn_interface.c
@@ -44,7 +44,7 @@ pthread_mutex_t svc_mut=PTHREAD_MUTEX_INITIALIZER;
 pthread_cond_t svc_con=PTHREAD_COND_INITIALIZER;
 int numLoops;
 parodusOnPingStatusChangeHandler on_ping_status_change;
- 
+
 /*----------------------------------------------------------------------------*/
 /*                                   Mocks                                    */
 /*----------------------------------------------------------------------------*/
@@ -335,6 +335,7 @@ void test_createSocketConnection()
 
 void test_createSocketConnection1()
 {
+    numLoops =0;
     noPollCtx *ctx;
     ParodusCfg cfg;
     memset(&cfg,0, sizeof(ParodusCfg));
@@ -364,11 +365,11 @@ void test_createSocketConnection1()
     expect_function_call(nopoll_ctx_unref);
     expect_function_call(nopoll_cleanup_library);
     createSocketConnection(NULL);
-    
 }
 
 void test_PingMissIntervalTime()
 {
+    numLoops = 6;
     noPollCtx *ctx;
     ParodusCfg cfg;
     memset(&cfg,0,sizeof(ParodusCfg));
@@ -386,7 +387,6 @@ void test_PingMissIntervalTime()
     //Max ping timeout is 6 sec
     cfg.webpa_ping_timeout = 6;
     set_parodus_cfg(&cfg);
-    
     reset_close_retry();
     expect_function_call(nopoll_thread_handlers);
     
@@ -422,11 +422,11 @@ void test_PingMissIntervalTime()
     expect_function_call(nopoll_ctx_unref);
     expect_function_call(nopoll_cleanup_library);
     createSocketConnection(NULL);
-    
 }
 
 void err_createSocketConnection()
 {
+    numLoops =0;
     set_close_retry();
     reset_heartBeatTimer();
     expect_function_call(nopoll_thread_handlers);
@@ -459,6 +459,7 @@ void err_createSocketConnection()
 
 void test_createSocketConnection_cloud_disconn()
 {
+        numLoops =0;
 	ParodusCfg cfg;
 	memset(&cfg,0,sizeof(ParodusCfg));
 	cfg.cloud_disconnect = strdup("XPC");


### PR DESCRIPTION
To fix connection stuck issue as parodus tend to shutdown existing process when close_retry set is delayed from event handler thread.  Remove close_retry dependency in main thread and trigger shutdown only when g_shutdown is true.