### PR TITLE
Use monotonic clock for heartBeat timer calculation.

### DIFF
--- a/src/conn_interface.c
+++ b/src/conn_interface.c
@@ -77,6 +77,7 @@ void createSocketConnection(void (* initKeypress)())
     server_list_t server_list;  
     bool seshat_registered = false;
     int create_conn_rtn = 0;
+    int nopoll_returnvalue = 0;	
     unsigned int webpa_ping_timeout_ms = 1000 * get_parodus_cfg()->webpa_ping_timeout;
     unsigned int heartBeatTimer = 0;
     struct timespec start_svc_alive_timer;
@@ -131,14 +132,17 @@ void createSocketConnection(void (* initKeypress)())
         struct timespec start, stop, diff;
         int time_taken_ms;
 
-        clock_gettime(CLOCK_REALTIME, &start);
-        nopoll_loop_wait(ctx, 5000000);
-        clock_gettime(CLOCK_REALTIME, &stop);
+        clock_gettime(CLOCK_MONOTONIC, &start);
+        nopoll_returnvalue = nopoll_loop_wait(ctx, 5000000);
+        clock_gettime(CLOCK_MONOTONIC, &stop);
 
         timespec_diff(&start, &stop, &diff);
         time_taken_ms = diff.tv_sec * 1000 + (diff.tv_nsec / 1000000);
-
-        // ParodusInfo("nopoll_loop_wait() time %d msec\n", time_taken_ms);
+	if(time_taken_ms/1000 != 5)
+	{
+        	ParodusInfo("nopoll_loop_wait value %d,nopoll_loop_wait() time %d msec\n",nopoll_returnvalue, time_taken_ms);
+	}
+	ParodusPrint("webpa_ping_timeout_ms %d msec\n", webpa_ping_timeout_ms);
 	heartBeatTimer = get_heartBeatTimer();
         if(heartBeatTimer >= webpa_ping_timeout_ms)
         {

--- a/src/time.c
+++ b/src/time.c
@@ -34,7 +34,7 @@ uint64_t getCurrentTimeInMicroSeconds(struct timespec *timer)
     ParodusPrint("timer->tv_sec : %lu\n",timer->tv_sec);
     ParodusPrint("timer->tv_nsec : %lu\n",timer->tv_nsec);
     systime = (uint64_t)timer->tv_sec * 1000000L + timer->tv_nsec/ 1000;
-    return systime;	
+    return systime;
 }
 
 long timeValDiff(struct timespec *starttime, struct timespec *finishtime)


### PR DESCRIPTION
Realtime to monotonic clock changes  to prevent the ping miss that happens on every reboot where NTP sync is delayed. 