### PR TITLE
Fix:factory reset and power off time is too slow

### DIFF
--- a/src/conn_interface.c
+++ b/src/conn_interface.c
@@ -240,8 +240,15 @@ void createSocketConnection(void (* initKeypress)())
 
 void shutdownSocketConnection(char *reason) {
    set_global_shutdown_reason (reason);
-   g_shutdown = true;
-   reset_interface_down_event ();
-   terminate_backoff_delay ();
+   if(g_shutdown == false)
+   {
+    g_shutdown = true;
+    reset_interface_down_event ();
+    terminate_backoff_delay ();
+   }
+   else
+   {
+	ParodusInfo("Shutdown already in progress\n");
+   }
 }
 

--- a/src/service_alive.c
+++ b/src/service_alive.c
@@ -44,6 +44,12 @@ static int wait__ (unsigned int secs)
 
   clock_gettime(CLOCK_REALTIME, &svc_alive_timer);
   svc_alive_timer.tv_sec += secs;
+  if (g_shutdown)
+  {
+    ParodusInfo("g_shutdown breaking service alive wait\n");    
+    shutdown_flag = g_shutdown;	 
+    return shutdown_flag;
+  }
   pthread_mutex_lock(&svc_mut);
   pthread_cond_timedwait (&svc_con, &svc_mut, &svc_alive_timer);
   shutdown_flag = g_shutdown;


### PR DESCRIPTION
Resolved deadlock issue, when two signals are emitted same instance.
Added g_shutdown check before going to serviceAliveTask wait 